### PR TITLE
Modified to allow changing all sshd_config options.

### DIFF
--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -257,6 +257,9 @@ GatewayPorts <%= options['GatewayPorts'] %>
 <% end -%>
 <% if @options['X11Forwarding'] -%>
 X11Forwarding <%= options['X11Forwarding'] %>
+<% elsif @osfamily == 'Debian' || @osfamily == 'RedHat' -%>
+# Debian and RedHat set X11Forwarding to yes.
+X11Forwarding yes
 <% else -%>
 #X11Forwarding no
 <% end -%>


### PR DESCRIPTION
This version is based on the latest OpenSSH sshd_config file and allows changing all sshd_config options.
Mostly follows the OpenSSH strategy of retaining unchanged options in the file with their default value but commented out.
