### PR TITLE
Fix variables for listen_address and permit_root_login so that templa…

### DIFF
--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -28,12 +28,12 @@ AddressFamily <%= @options['AddressFamily'] %>
 <% end -%>
 #ListenAddress 0.0.0.0
 #ListenAddress ::
-<% if listen_address.respond_to?('each') -%>
-<% listen_address.each do |listener| -%>
+<% if @listen_address.respond_to?('each') -%>
+<% @listen_address.each do |listener| -%>
 ListenAddress <%= listener %>
 <% end -%>
 <% else -%>
-ListenAddress <%= listen_address %>
+ListenAddress <%= @listen_address %>
 <% end -%>
 
 # The default requires explicit activation of protocol 1 starting
@@ -94,7 +94,7 @@ LoginGraceTime <%= @options['LoginGraceTime'] %>
 <% else -%>
 #LoginGraceTime 2m
 <% end -%>
-PermitRootLogin <%= permit_root_login %>
+PermitRootLogin <%= @permit_root_login %>
 <% if @options['StrictModes'] -%>
 StrictModes <%= @options['StrictModes'] %>
 <% else -%>


### PR DESCRIPTION
Fix variables for listen_address and permit_root_login so that template can parse on PE and CentOS 7.

Fixes: 

"Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Evaluation Error: Error while evaluating a Function Call, Failed to parse template ssh/sshd_config.erb:
  Filepath: /etc/puppetlabs/code/environments/production/modules/ssh/templates/sshd_config.erb
  Line: 25
  Detail: undefined local variable or method `listen_address' for #<Puppet::Parser::TemplateWrapper:0x6d631b42>"