### PR TITLE
fixed template support. added Cipher option for sshd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-.puppet-lint.rc

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.puppet-lint.rc

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -3,7 +3,7 @@
 # Manage SSH on a system
 #
 # == Parameters:
-# 
+#
 # [*ensure*]
 #    What state to ensure for the package. Accepts the same values
 #    as the parameter of the same name for a package type.
@@ -43,7 +43,7 @@
 #    Default: 0.0.0.0
 #
 # == Author:
-# 
+#
 #    Patrick Schoenfeld <patrick.schoenfeld@credativ.de>
 #
 class ssh::server (
@@ -80,7 +80,7 @@ class ssh::server (
         }
 
         concat::fragment { 'sshd_config_base':
-            content => template('ssh/sshd_config.erb'),
+            content => template($config_template),
             target  => '/etc/ssh/sshd_config',
             order   => '01',
         }

--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -407,3 +407,6 @@ DenyGroups <%= @options['DenyGroups'] %>
 AllowGroups <%= @options['AllowGroups'] %>
 <% end -%>
 <% end -%>
+<% if @options['Ciphers'] -%>
+ Ciphers <%= @options['Ciphers'] -%>
+<% end -%>


### PR DESCRIPTION
the config_template option was not implemented.

also added support for Ciphers
Per man
```
Ciphers
             Specifies the ciphers allowed for protocol version 2.  Multiple ciphers must be comma-separated.  The supported ciphers are “3des-cbc”, “aes128-cbc”, “aes192-cbc”, “aes256-cbc”, “aes128-ctr”, “aes192-ctr”,
             “aes256-ctr”, “arcfour128”, “arcfour256”, “arcfour”, “blowfish-cbc”, “rijndael-cbc@lysator.liu.se”, and “cast128-cbc”.  The default is:

                aes128-ctr,aes192-ctr,aes256-ctr,arcfour256,arcfour128,
                aes128-cbc,3des-cbc,blowfish-cbc,cast128-cbc,aes192-cbc,
                aes256-cbc,arcfour,rijndael-cbc@lysator.liu.se
```