### PR TITLE
Remove whitespace in front of Ciphers setting

### DIFF
--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -408,5 +408,5 @@ AllowGroups <%= @options['AllowGroups'] %>
 <% end -%>
 <% end -%>
 <% if @options['Ciphers'] -%>
- Ciphers <%= @options['Ciphers'] -%>
+Ciphers <%= @options['Ciphers'] -%>
 <% end -%>


### PR DESCRIPTION
The last pull request added a whitespace in front of the Ciphers setting. This will remove it as it is unnecessary and it can break things looking for ^Ciphers in the sshd_config file.