### PR TITLE
Use corect format for name in metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-  "name": "aptituz/ssh",
+  "name": "aptituz-ssh",
   "version": "3.0.0",
   "author": "Patrick Schoenfeld <patrick.schoenfeld@credativ.de>",
   "summary": "puppet module to manage ssh",


### PR DESCRIPTION
metadata-json-lint complains that the name in metadata.json should be separated with a hyphen, not a slash. This MR fixes that.